### PR TITLE
refactor: move Vin.cmds & Vin.lib to require()

### DIFF
--- a/lua/vin/cmds/edit.lua
+++ b/lua/vin/cmds/edit.lua
@@ -1,3 +1,5 @@
+local utils = require("vin.lib.utils")
+
 local M = {}
 
 local AUTO_LOG_PREFIX = "Test"
@@ -22,7 +24,7 @@ end
 
 M.log_symbol = function()
     local current_word = vim.fn.expand("<cword>")
-    local current_filename = Vin.lib.utils.get_current_filename(true)
+    local current_filename = utils.get_current_filename(true)
 
     local message = table.concat({
         '"',

--- a/lua/vin/cmds/fuzzy.lua
+++ b/lua/vin/cmds/fuzzy.lua
@@ -1,3 +1,5 @@
+local utils = require("vin.lib.utils")
+
 local delta_previewer = require("telescope.previewers").new_termopen_previewer({
     get_command = function(entry)
         -- this is for status
@@ -54,7 +56,7 @@ M.find_commits = function()
 end
 
 M.find_related_files = function()
-    local current_filename = Vin.lib.utils.get_current_filename(false)
+    local current_filename = utils.get_current_filename(false)
 
     if current_filename then
         M.telescope("find_files", {

--- a/lua/vin/cmds/general.lua
+++ b/lua/vin/cmds/general.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 M.center_line_vertical = function()
-    vim.cmd([[norm zz]])
+    vim.cmd.norm("zz")
 end
 
 M.toggle_quickfix = function()

--- a/lua/vin/cmds/git.lua
+++ b/lua/vin/cmds/git.lua
@@ -1,4 +1,6 @@
-local _, gitsigns = pcall(require, "gitsigns")
+local general = require("vin.cmds.general")
+local utils = require("vin.lib.utils")
+local gitsigns = require("gitsigns")
 
 local M = {}
 
@@ -17,22 +19,22 @@ end
 
 M.blame_line = function()
     gitsigns.blame_line()
-    Vin.cmds.general.center_line_vertical()
+    general.center_line_vertical()
 end
 
 M.hunk_reset = function()
     gitsigns.reset_hunk()
-    Vin.cmds.general.center_line_vertical()
+    general.center_line_vertical()
 end
 
 M.hunk_go_prev = function()
     gitsigns.prev_hunk()
-    Vin.cmds.general.center_line_vertical()
+    general.center_line_vertical()
 end
 
 M.hunk_go_next = function()
     gitsigns.next_hunk()
-    Vin.cmds.general.center_line_vertical()
+    general.center_line_vertical()
 end
 
 M.hunk_stage = function()
@@ -64,7 +66,7 @@ M.get_diff_to_master = function()
     local commonMasterBranchNames = { "master", "main" }
 
     local handleInput = function(branchName)
-        if Vin.lib.utils.includes(commonMasterBranchNames, branchName) then
+        if utils.includes(commonMasterBranchNames, branchName) then
             vim.cmd("DiffviewOpen origin/" .. branchName .. "...HEAD")
             diffview_notification(branchName)
         end
@@ -82,14 +84,11 @@ M.get_diff_to = function()
     }
 
     local handleDiffToBranch = function()
-        local branches = Vin.lib.utils.get_all_branches()
+        local branches = utils.get_all_branches()
 
         -- Remove the current branch from the selection
-        local current_branch = Vin.lib.utils.get_current_branch()
-        local index_of_current_branch = Vin.lib.utils.find_index(
-            branches,
-            current_branch
-        )
+        local current_branch = utils.get_current_branch()
+        local index_of_current_branch = utils.find_index(branches, current_branch)
         table.remove(branches, index_of_current_branch)
 
         vim.ui.select(branches, {

--- a/lua/vin/cmds/init.lua
+++ b/lua/vin/cmds/init.lua
@@ -1,4 +1,4 @@
-Vin.cmds = {
+return {
     general = require("vin.cmds.general"),
     nav = require("vin.cmds.nav"),
     edit = require("vin.cmds.edit"),

--- a/lua/vin/config.lua
+++ b/lua/vin/config.lua
@@ -1,4 +1,4 @@
-local join = Vin.lib.utils.join
+local join = require("vin.lib.utils").join
 
 local HOME_PATH = "~/"
 local CONFIG_PATH = join(HOME_PATH, ".config/")

--- a/lua/vin/init.lua
+++ b/lua/vin/init.lua
@@ -1,7 +1,5 @@
 ---@class Vin
 _G.Vin = {
-    lib = {},
-    cmds = {},
     icons = {},
     config = {},
 }
@@ -15,10 +13,5 @@ require("vin.autocmds")
 require("vin.cmds")
 require("vin.keymaps")
 
--- Setup colorscheme
-function InitColorScheme(color)
-    color = color or "default"
-    vim.cmd.colorscheme(color)
-end
-
-InitColorScheme(Vin.config.colorscheme)
+-- Initialize colorscheme
+require("vin.lib.utils").init_colorscheme(Vin.config.colorscheme)

--- a/lua/vin/keymaps/groups.lua
+++ b/lua/vin/keymaps/groups.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-local cmds = Vin.cmds
+local cmds = require("vin.cmds")
 
 M.advanced_g = {
     name = "Go-To",
@@ -38,21 +38,21 @@ M.go_prev = {
     q = {
         function()
             vim.cmd([[cprev]])
-            Vin.cmds.general.center_line_vertical()
+            cmds.general.center_line_vertical()
         end,
         "QuickFix Item",
     },
     l = {
         function()
             vim.cmd([[lprev]])
-            Vin.cmds.general.center_line_vertical()
+            cmds.general.center_line_vertical()
         end,
         "LocList Item",
     },
     b = {
         function()
             vim.cmd([[bprev]])
-            Vin.cmds.general.center_line_vertical()
+            cmds.general.center_line_vertical()
         end,
         "Buffer",
     },
@@ -69,7 +69,7 @@ M.go_prev = {
         end,
         "Prev Trouble",
     },
-    g = { Vin.cmds.git.hunk_go_prev, "Change" },
+    g = { cmds.git.hunk_go_prev, "Change" },
 }
 
 M.go_next = {
@@ -77,21 +77,21 @@ M.go_next = {
     q = {
         function()
             vim.cmd([[cnext]])
-            Vin.cmds.general.center_line_vertical()
+            cmds.general.center_line_vertical()
         end,
         "QuickFix Item",
     },
     l = {
         function()
             vim.cmd([[lnext]])
-            Vin.cmds.general.center_line_vertical()
+            cmds.general.center_line_vertical()
         end,
         "LocList Item",
     },
     b = {
         function()
             vim.cmd([[bnext]])
-            Vin.cmds.general.center_line_vertical()
+            cmds.general.center_line_vertical()
         end,
         "Buffer",
     },
@@ -107,7 +107,7 @@ M.go_next = {
         end,
         "Next Trouble",
     },
-    g = { Vin.cmds.git.hunk_go_next, "Change" },
+    g = { cmds.git.hunk_go_next, "Change" },
 }
 
 M.diagnostics = {
@@ -144,32 +144,32 @@ M.explorer = {
 M.quit = {
     name = "Quit",
     q = { "<cmd>silent q<CR>", "Quit Split (:q)" },
-    c = { Vin.cmds.quit.custom_buffers, "Custom Filter" },
-    o = { Vin.cmds.quit.other_buffers, "Other" },
-    h = { Vin.cmds.quit.hidden_buffers, "Hidden" },
-    a = { Vin.cmds.quit.all_buffers, "All" },
+    c = { cmds.quit.custom_buffers, "Custom Filter" },
+    o = { cmds.quit.other_buffers, "Other" },
+    h = { cmds.quit.hidden_buffers, "Hidden" },
+    a = { cmds.quit.all_buffers, "All" },
 }
 
 M.copy = {
     name = "Copy",
-    f = { Vin.cmds.copy.fullPath, "Copy Full Path" },
-    r = { Vin.cmds.copy.relativePath, "Copy Relative Path" },
-    n = { Vin.cmds.copy.fileName, "Copy File Name" },
+    f = { cmds.copy.fullPath, "Copy Full Path" },
+    r = { cmds.copy.relativePath, "Copy Relative Path" },
+    n = { cmds.copy.fileName, "Copy File Name" },
 }
 
 M.git = {
     name = "Git",
-    k = { Vin.cmds.git.hunk_go_prev, "Change" },
-    j = { Vin.cmds.git.hunk_go_next, "Change" },
+    k = { cmds.git.hunk_go_prev, "Change" },
+    j = { cmds.git.hunk_go_next, "Change" },
 
-    g = { Vin.cmds.term.toggle_gitui, "LazyGit" },
+    g = { cmds.term.toggle_gitui, "LazyGit" },
     s = { "<cmd>Neotree git_status float<CR>", "Git Status" },
-    q = { Vin.cmds.git.open_changes_in_qf, "List changes in QF" },
-    l = { Vin.cmds.git.toggle_current_line_blame, "Current Line Blame" },
-    o = { Vin.cmds.fuzzy.find_changed_files, "Open Changed Files" },
+    q = { cmds.git.open_changes_in_qf, "List changes in QF" },
+    l = { cmds.git.toggle_current_line_blame, "Current Line Blame" },
+    o = { cmds.fuzzy.find_changed_files, "Open Changed Files" },
     d = {
         name = "Diffview",
-        c = { Vin.cmds.git.get_diff_to, "Diff To Custom" },
+        c = { cmds.git.get_diff_to, "Diff To Custom" },
         d = { "<cmd>DiffviewOpen<CR>", "Current Diff" },
         h = { "<cmd>DiffviewFileHistory %<CR>", "History for Current File" },
         H = { "<cmd>DiffviewFileHistory<CR>", "Git History" },
@@ -178,23 +178,23 @@ M.git = {
     },
     h = {
         name = "Hunk",
-        k = { Vin.cmds.git.hunk_go_prev, "Prev Hunk" },
-        j = { Vin.cmds.git.hunk_go_next, "Next Hunk" },
-        s = { Vin.cmds.git.hunk_stage, "Stage Hunk" },
-        S = { Vin.cmds.git.hunk_undo_stage, "Undo Stage Hunk" },
-        p = { Vin.cmds.git.hunk_preview, "Preview Hunk" },
-        r = { Vin.cmds.git.hunk_reset, "Reset Hunk" },
-        b = { Vin.cmds.git.blame_line, "Blame Line" },
+        k = { cmds.git.hunk_go_prev, "Prev Hunk" },
+        j = { cmds.git.hunk_go_next, "Next Hunk" },
+        s = { cmds.git.hunk_stage, "Stage Hunk" },
+        S = { cmds.git.hunk_undo_stage, "Undo Stage Hunk" },
+        p = { cmds.git.hunk_preview, "Preview Hunk" },
+        r = { cmds.git.hunk_reset, "Reset Hunk" },
+        b = { cmds.git.blame_line, "Blame Line" },
     },
     b = {
         name = "Buffer",
-        s = { Vin.cmds.git.buffer_stage, "Stage Buffer" },
-        r = { Vin.cmds.git.buffer_reset, "Reset Buffer" },
+        s = { cmds.git.buffer_stage, "Stage Buffer" },
+        r = { cmds.git.buffer_reset, "Reset Buffer" },
     },
     c = {
         name = "Checkout",
         b = { "<cmd>Telescope git_branches<CR>", "Branches" },
-        c = { Vin.cmds.fuzzy.find_commits, "Commits" },
+        c = { cmds.fuzzy.find_commits, "Commits" },
     },
     p = {
         name = "Pull Request",
@@ -215,8 +215,8 @@ M.search = {
     c = { "<cmd>Telescope colorscheme<CR>", "Colorscheme" },
     h = { "<cmd>Telescope oldfiles<CR>", "Recent Files (History)" },
     m = { "<cmd>Telescope marks<CR>", "Marks" },
-    g = { Vin.cmds.fuzzy.find_changed_files, "Open Changed Files" },
-    r = { Vin.cmds.fuzzy.find_related_files, "Related Files" },
+    g = { cmds.fuzzy.find_changed_files, "Open Changed Files" },
+    r = { cmds.fuzzy.find_related_files, "Related Files" },
     s = {
         name = "Symbols",
         d = { "<cmd>Telescope lsp_document_symbols<CR>", "Symbols In Document" },
@@ -248,7 +248,7 @@ M.search = {
     },
     a = {
         name = "Advanced",
-        s = { Vin.cmds.fuzzy.find_scss_symbol, "SCSS Symbol" },
+        s = { cmds.fuzzy.find_scss_symbol, "SCSS Symbol" },
         h = { "<cmd>Telescope help_tags<CR>", "Help Tags" },
         H = { "<cmd>Telescope highlights<CR>", "Highlights" },
         m = { "<cmd>Telescope man_pages<CR>", "Man Pages" },
@@ -259,13 +259,13 @@ M.search = {
         name = "Folders",
         c = {
             function()
-                Vin.cmds.fuzzy.search_in_dir(Vin.config.pathes.config)
+                cmds.fuzzy.search_in_dir(Vin.config.pathes.config)
             end,
             "~/.config",
         },
         v = {
             function()
-                Vin.cmds.fuzzy.search_in_dir(Vin.config.pathes.nvimConfig)
+                cmds.fuzzy.search_in_dir(Vin.config.pathes.nvimConfig)
             end,
             "~/.config/nvim (Vin)",
         },
@@ -273,13 +273,13 @@ M.search = {
             name = "Notes",
             w = {
                 function()
-                    Vin.cmds.fuzzy.search_in_dir(Vin.config.pathes.notes.work)
+                    cmds.fuzzy.search_in_dir(Vin.config.pathes.notes.work)
                 end,
                 "Work Notes",
             },
             n = {
                 function()
-                    Vin.cmds.fuzzy.search_in_dir(Vin.config.pathes.notes.private)
+                    cmds.fuzzy.search_in_dir(Vin.config.pathes.notes.private)
                 end,
                 "Private Notes",
             },
@@ -289,59 +289,59 @@ M.search = {
 
 M.marks = {
     name = "Marks",
-    a = { Vin.cmds.harpoon.add_file, "Add File to Harpoon" },
-    m = { Vin.cmds.harpoon.toggle_quick_menu, "Harpoon Menu" },
+    a = { cmds.harpoon.add_file, "Add File to Harpoon" },
+    m = { cmds.harpoon.toggle_quick_menu, "Harpoon Menu" },
     ["1"] = {
         function()
-            Vin.cmds.harpoon.jump_to_file(1)
+            cmds.harpoon.jump_to_file(1)
         end,
         " ",
     },
     ["2"] = {
         function()
-            Vin.cmds.harpoon.jump_to_file(2)
+            cmds.harpoon.jump_to_file(2)
         end,
         " ",
     },
     ["3"] = {
         function()
-            Vin.cmds.harpoon.jump_to_file(3)
+            cmds.harpoon.jump_to_file(3)
         end,
         " ",
     },
     ["4"] = {
         function()
-            Vin.cmds.harpoon.jump_to_file(4)
+            cmds.harpoon.jump_to_file(4)
         end,
         " ",
     },
     ["5"] = {
         function()
-            Vin.cmds.harpoon.jump_to_file(5)
+            cmds.harpoon.jump_to_file(5)
         end,
         " ",
     },
     ["6"] = {
         function()
-            Vin.cmds.harpoon.jump_to_file(6)
+            cmds.harpoon.jump_to_file(6)
         end,
         " ",
     },
     ["7"] = {
         function()
-            Vin.cmds.harpoon.jump_to_file(7)
+            cmds.harpoon.jump_to_file(7)
         end,
         " ",
     },
     ["8"] = {
         function()
-            Vin.cmds.harpoon.jump_to_file(8)
+            cmds.harpoon.jump_to_file(8)
         end,
         " ",
     },
     ["9"] = {
         function()
-            Vin.cmds.harpoon.jump_to_file(9)
+            cmds.harpoon.jump_to_file(9)
         end,
         " ",
     },
@@ -472,8 +472,8 @@ M.action = {
     },
     l = {
         name = "Log",
-        l = { Vin.cmds.edit.log_symbol, "Auto Log Symbol" },
-        d = { Vin.cmds.edit.delete_logs, "Delete Logs" },
+        l = { cmds.edit.log_symbol, "Auto Log Symbol" },
+        d = { cmds.edit.delete_logs, "Delete Logs" },
     },
 }
 

--- a/lua/vin/keymaps/normal.lua
+++ b/lua/vin/keymaps/normal.lua
@@ -1,3 +1,4 @@
+local cmds = require("vin.cmds")
 local groups = require("vin.keymaps.groups")
 
 local M = {}
@@ -29,31 +30,31 @@ M.no_leader = {
     -- NOTE: This requires some settings in kitty to be working
     ["<C-1>"] = {
         function()
-            Vin.cmds.harpoon.jump_to_file(1)
+            cmds.harpoon.jump_to_file(1)
         end,
         " ",
     },
     ["<C-2>"] = {
         function()
-            Vin.cmds.harpoon.jump_to_file(2)
+            cmds.harpoon.jump_to_file(2)
         end,
         " ",
     },
     ["<C-3>"] = {
         function()
-            Vin.cmds.harpoon.jump_to_file(3)
+            cmds.harpoon.jump_to_file(3)
         end,
         " ",
     },
     ["<C-4>"] = {
         function()
-            Vin.cmds.harpoon.jump_to_file(4)
+            cmds.harpoon.jump_to_file(4)
         end,
         " ",
     },
     ["<C-5>"] = {
         function()
-            Vin.cmds.harpoon.jump_to_file(5)
+            cmds.harpoon.jump_to_file(5)
         end,
         " ",
     },
@@ -74,9 +75,9 @@ M.no_leader = {
     ["<M-j>"] = { "<Esc>:m .+1<CR>", "Move Down" },
 
     -- Control bindings
-    ["<C-f>"] = { Vin.cmds.nav.pick_window, "  Pick Window" },
-    ["<C-q>"] = { Vin.cmds.general.toggle_quickfix, "Toggle Quick Fix" },
-    ["<C-'>"] = { Vin.cmds.term.toggle, "Term" },
+    ["<C-f>"] = { cmds.nav.pick_window, "  Pick Window" },
+    ["<C-q>"] = { cmds.general.toggle_quickfix, "Toggle Quick Fix" },
+    ["<C-'>"] = { cmds.term.toggle, "Term" },
 
     -- FN Key Bindings
     ["<F7>"] = { "<cmd>CccPick<CR>", "Color Picker" },

--- a/lua/vin/keymaps/term.lua
+++ b/lua/vin/keymaps/term.lua
@@ -1,7 +1,9 @@
+local cmds = require("vin.cmds")
+
 local M = {}
 
 M.no_leader = {
-    ["<C-'>"] = { Vin.cmds.term.toggle, "Term" },
+    ["<C-'>"] = { cmds.term.toggle, "Term" },
 }
 
 return M

--- a/lua/vin/keymaps/visual.lua
+++ b/lua/vin/keymaps/visual.lua
@@ -6,7 +6,6 @@ M.no_leader = {
     -- Better Indent
     ["<"] = { "<gv", WhichKeyIgnoreLabel },
     [">"] = { ">gv", WhichKeyIgnoreLabel },
-
     -- Move to beginning and end of line
     ["H"] = { "^", WhichKeyIgnoreLabel },
     ["L"] = { "$", WhichKeyIgnoreLabel },

--- a/lua/vin/lib/git.lua
+++ b/lua/vin/lib/git.lua
@@ -1,3 +1,5 @@
+local utils = require("vin.lib.utils")
+
 local M = {}
 
 ---Find out current branch
@@ -25,7 +27,7 @@ M.get_all_branches = function()
         local stripped = string.gsub(string.gsub(read_branches, "*", ""), "\n", "")
 
         -- Now split the string by spaces into a table and return it
-        local all_branches = Vin.lib.utils.split_by_space(stripped)
+        local all_branches = utils.split_by_space(stripped)
         return all_branches
     end
 end

--- a/lua/vin/lib/init.lua
+++ b/lua/vin/lib/init.lua
@@ -1,4 +1,4 @@
-Vin.lib = {
+return {
     utils = require("vin.lib.utils"),
     git = require("vin.lib.git"),
     lsp = require("vin.lib.lsp"),

--- a/lua/vin/lib/utils.lua
+++ b/lua/vin/lib/utils.lua
@@ -152,4 +152,11 @@ M.is_running_nightly = function(callback)
     M.validate_nvim_version(Vin.config.nightly_version, callback)
 end
 
+---Setup colorscheme
+---@param color string The name of the colorscheme
+M.init_colorscheme = function(color)
+    color = color or "default"
+    vim.cmd.colorscheme(color)
+end
+
 return M

--- a/lua/vin/plugins/ccc.lua
+++ b/lua/vin/plugins/ccc.lua
@@ -93,28 +93,28 @@ local spec = {
                 ---@type boolean
                 lsp = true,
             },
-    -- stylua: ignore
-    ---@type {[1]: ColorPicker, [2]: ColorOutput}[]
-    convert = {
-        { picker.hex, output.css_rgb },
-        { picker.css_rgb, output.css_hsl },
-        { picker.css_hsl, output.hex },
-    },
+            -- stylua: ignore
+            ---@type {[1]: ColorPicker, [2]: ColorOutput}[]
+            convert = {
+                { picker.hex, output.css_rgb },
+                { picker.css_rgb, output.css_hsl },
+                { picker.css_hsl, output.hex },
+            },
             recognize = {
                 input = false,
                 output = false,
-        -- stylua: ignore
-        ---@alias RecognizePattern table<ColorPicker, {[1]: ColorInput, [2]: ColorOutput}>
-        ---@type RecognizePattern
-        pattern = {
-            [picker.css_rgb] = { input.rgb, output.rgb },
-            [picker.css_name] = { input.rgb, output.rgb },
-            [picker.hex] = { input.rgb, output.hex },
-            [picker.css_hsl] = { input.hsl, output.css_hsl },
-            [picker.css_hwb] = { input.hwb, output.css_hwb },
-            [picker.css_lab] = { input.lab, output.css_lab },
-            [picker.css_lch] = { input.lch, output.css_lch },
-        },
+                -- stylua: ignore
+                ---@alias RecognizePattern table<ColorPicker, {[1]: ColorInput, [2]: ColorOutput}>
+                ---@type RecognizePattern
+                pattern = {
+                    [picker.css_rgb] = { input.rgb, output.rgb },
+                    [picker.css_name] = { input.rgb, output.rgb },
+                    [picker.hex] = { input.rgb, output.hex },
+                    [picker.css_hsl] = { input.hsl, output.css_hsl },
+                    [picker.css_hwb] = { input.hwb, output.css_hwb },
+                    [picker.css_lab] = { input.lab, output.css_lab },
+                    [picker.css_lch] = { input.lch, output.css_lch },
+                },
             },
             ---@type table<string, function>
             mappings = {

--- a/lua/vin/plugins/lsp/init.lua
+++ b/lua/vin/plugins/lsp/init.lua
@@ -1,3 +1,5 @@
+local utils = require("vin.lib.utils")
+
 return {
     {
         "williamboman/mason.nvim",
@@ -96,7 +98,7 @@ return {
                 },
             }
 
-            lsp_zero.setup_servers(Vin.lib.utils.merge({
+            lsp_zero.setup_servers(utils.merge({
                 Vin.config.mason.ensure_installed.servers,
                 shared_lsp_opts,
             }))

--- a/lua/vin/plugins/lsp/servers/cssls.lua
+++ b/lua/vin/plugins/lsp/servers/cssls.lua
@@ -1,8 +1,8 @@
+local disable_client_formating = require("vin.lib.lsp").disable_client_formating
+
 local M = {}
 
 function M.setup(lsp_zero)
-    local disable_client_formating = Vin.lib.lsp.disable_client_formating
-
     lsp_zero.configure("cssls", {
         on_init = function(client)
             -- We want to format with null-ls, so we disable the native formatter

--- a/lua/vin/plugins/lsp/servers/denols.lua
+++ b/lua/vin/plugins/lsp/servers/denols.lua
@@ -1,8 +1,8 @@
+local disable_client_formating = require("vin.lib.lsp").disable_client_formating
+
 local M = {}
 
 function M.setup(lsp_zero)
-    local disable_client_formating = Vin.lib.lsp.disable_client_formating
-
     lsp_zero.configure("denols", {
         on_init = function(client)
             -- We want to format with null-ls, so we disable the native formatter

--- a/lua/vin/plugins/lsp/servers/sumneko_lua.lua
+++ b/lua/vin/plugins/lsp/servers/sumneko_lua.lua
@@ -1,8 +1,8 @@
+local disable_client_formating = require("vin.lib.lsp").disable_client_formating
+
 local M = {}
 
 function M.setup(lsp_zero)
-    local disable_client_formating = Vin.lib.lsp.disable_client_formating
-
     -- Setup neodev if present
     -- NOTE: neodev will only setup types for my own neovim config
     -- Source: https://github.com/folke/neodev.nvim#-setup

--- a/lua/vin/plugins/lsp/servers/tsserver.lua
+++ b/lua/vin/plugins/lsp/servers/tsserver.lua
@@ -1,8 +1,8 @@
+local disable_client_formating = require("vin.lib.lsp").disable_client_formating
+
 local M = {}
 
 function M.setup(lsp_zero)
-    local disable_client_formating = Vin.lib.lsp.disable_client_formating
-
     ---@see https://github.com/typescript-language-server/typescript-language-server#initializationoptions
     ---@see https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#tsserver
     lsp_zero.configure("tsserver", {

--- a/lua/vin/plugins/lualine.lua
+++ b/lua/vin/plugins/lualine.lua
@@ -1,9 +1,9 @@
+local join = require("vin.lib.utils").join
+
 return {
     "nvim-lualine/lualine.nvim",
     event = "VeryLazy",
     opts = function()
-        local join = Vin.lib.utils.join
-
         local hide_in_width = function()
             return vim.fn.winwidth(0) > 80
         end
@@ -31,10 +31,14 @@ return {
 
         local project_name = {
             function()
-                local current_project_folder =
-                    vim.fn.fnamemodify(vim.fn.getcwd(), ":t")
-                local parent_project_folder =
-                    vim.fn.fnamemodify(vim.fn.getcwd(), ":h:t")
+                local current_project_folder = vim.fn.fnamemodify(
+                    vim.fn.getcwd(),
+                    ":t"
+                )
+                local parent_project_folder = vim.fn.fnamemodify(
+                    vim.fn.getcwd(),
+                    ":h:t"
+                )
                 return Vin.icons.documents.Folder
                     .. " "
                     .. parent_project_folder

--- a/lua/vin/plugins/telescope.lua
+++ b/lua/vin/plugins/telescope.lua
@@ -22,9 +22,8 @@ return {
         telescope.load_extension("noice")
     end,
     opts = function()
+        local merge = require("vin.lib.utils").merge
         local actions = require("telescope.actions")
-
-        local merge = Vin.lib.utils.merge
 
         local quick_vertical_window = {
             show_line = false,


### PR DESCRIPTION
[# Convert Vin.cmds & Vin.lib to require()](https://linear.app/nikbrunner/issue/VIN-18/convert-vincmds-and-vinlib-to-require)